### PR TITLE
Allow sign-in via a Client ID and Secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ npm install homebridge-nello -g
 ```
 
 ### Optional: Installation of FFMPEG
+
 **Only if you want to use a camera accessory. More information in the Configuration section.**
+
 You can install the default package or compile it yourself if you have a special case to fit.
+
 ```bash
 sudo apt-get install ffmpeg
 ```
+
 General information about ffmpeg can be found here https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki)
 
 Due to HomeKit limitations it's required to add the camera separately. Just tap on the plus button in the top right corner, choose "Add Accessory" and click on "Don't Have a Code or Can't Scan?". In the next view you should see the camera accessory. Tap it in order to add it to the Home app. The PIN is the same as of your HomeBridge instance.
@@ -25,14 +29,19 @@ Due to HomeKit limitations it's required to add the camera separately. Just tap 
 ## Retrieving a client ID and client secret from Nello
 
 **IMPORTANT:** Please visit https://auth.nello.io/admin/ and sign in with your username and password that you also use in the nello.io app.
+
 Fill in all required fields in the "Create API client" form (mark all "Allowed response type"s and "Allowed grant type"s). Copy the client ID and paste it into the configuration as seen below.
+
 If you are using a dedicated user account for this plugin, make sure that you use the credentials of this account to generate a client ID.
 
 ## Configuration
+
 There are multiple ways to get notifications if someone rings at your door:
 
 ### Default configuration (with a motion sensor for ring notifications)
+
 If you don't want to use a camera or don't have one this is the configuration for you.
+
 ```json
 {
     "platforms": [
@@ -55,8 +64,11 @@ If you don't want to use a camera or don't have one this is the configuration fo
 ```
 
 ### FFMPEG Stream (from a srtp source)
+
 If you have a doorbell with srtp support you can use this configuration.
+
 **You need to install ffmpeg if you want to see a picture in the Home app. Just take a look at last paragraph of the Installation part.**
+
 ```json
 {
     "platforms": [
@@ -88,6 +100,7 @@ If you have a doorbell with srtp support you can use this configuration.
 ```
 
 **Troubleshooting Guide for the video configuration:**
+
 * Make sure that you either use FFmpeg command line arguments for the `snapshotImage` property (e.g. `-i ...`) or provide a URL. If you use an https:// address, make sure that you compiled FFmpeg with openssl (which is not the case when you followed the installtion instructions for Raspberry PI from https://github.com/KhaosT/homebridge-camera-ffmpeg).
 * If you want to use a local image for the `snapshotImage` property, please set the property to `-i <absolute-path-to-your-image>`. Don't use `~`, use an absolute path and start your path with `/`.
 * We included a nice static image, which you can use. Therefore, set the `snapshotImage` property to `-i <absolute-path-to-your-global-node-modules>/homebridge-nello/assets/nello.png`. The path to your global node modules varies based on the OS and the installation method. On a Raspberry PI, it is usually in `/opt/node/lib/node_modules`.
@@ -95,8 +108,11 @@ If you have a doorbell with srtp support you can use this configuration.
 * If you still have troubles configuring the camera, feel free to create issues. Please provide your configuration.
 
 ### Raspberry Pi Camera Module V2.1
+
 If you're using a Raspberry Pi for HomeBridge and have a connected Camera Module, you can use this camera for notifications.
+
 **You need to install ffmpeg if you want to see a picture in the Home app. Just take a look at last paragraph of the Installation part.**
+
 ```json
 {
     "platforms": [

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ If you don't want to use a camera or don't have one this is the configuration fo
         {
             "platform" : "NelloPlatform",
             "name" : "nello.io",
-            "username": "<your-username>",
-            "password": "<your-password>",
+            "authType": "secret",
             "clientId": "<paste-client-id-here>",
+            "clientSecret": "<paste-client-secret-here>",
             "lockTimeout": 5000,
             "locationUpdateInterval": 3600000,
             "exposeReachability": true,
@@ -75,9 +75,9 @@ If you have a doorbell with srtp support you can use this configuration.
         {
             "platform" : "NelloPlatform",
             "name" : "nello.io",
-            "username": "<your-username>",
-            "password": "<your-password>",
+            "authType": "secret",
             "clientId": "<paste-client-id-here>",
+            "clientSecret": "<paste-client-secret-here>",
             "lockTimeout": 5000,
             "locationUpdateInterval": 3600000,
             "exposeReachability": true,
@@ -119,9 +119,9 @@ If you're using a Raspberry Pi for HomeBridge and have a connected Camera Module
         {
             "platform" : "NelloPlatform",
             "name" : "nello.io",
-            "username": "<your-username>",
-            "password": "<your-password>",
+            "authType": "secret",
             "clientId": "<paste-client-id-here>",
+            "clientSecret": "<paste-client-secret-here>",
             "lockTimeout": 5000,
             "locationUpdateInterval": 3600000,
             "exposeReachability": true,
@@ -141,9 +141,15 @@ If you're using a Raspberry Pi for HomeBridge and have a connected Camera Module
 }
 ```
 
-**username**: the email address of your nello.io account
+**authType** (optional): the method of authentication, either "password" or "secret". This is set to "password" for backwards compatibility with previous versions of this plugin, but it is recommended to use the "secret" method to avoid having to keep a username and password in plaintext in the configuration.
 
-**password**: the password of your account
+**clientId**: Client ID (read "Retrieving a client ID and client secret from Nello")/
+
+**clientSecret** (required for "secret" auth)
+
+**username** (required for "password" auth): the email address of your nello.io account.
+
+**password** (required for "password" auth): the password of your account.
 
 **lockTimeout** (optional): timeout in milliseconds, after which the lock will be displayed as locked after you unlock the door. Default value is 5000.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you don't want to use a camera or don't have one this is the configuration fo
         {
             "platform" : "NelloPlatform",
             "name" : "nello.io",
-            "authType": "secret",
+            "authType": "client",
             "clientId": "<paste-client-id-here>",
             "clientSecret": "<paste-client-secret-here>",
             "lockTimeout": 5000,
@@ -75,7 +75,7 @@ If you have a doorbell with srtp support you can use this configuration.
         {
             "platform" : "NelloPlatform",
             "name" : "nello.io",
-            "authType": "secret",
+            "authType": "client",
             "clientId": "<paste-client-id-here>",
             "clientSecret": "<paste-client-secret-here>",
             "lockTimeout": 5000,
@@ -119,7 +119,7 @@ If you're using a Raspberry Pi for HomeBridge and have a connected Camera Module
         {
             "platform" : "NelloPlatform",
             "name" : "nello.io",
-            "authType": "secret",
+            "authType": "client",
             "clientId": "<paste-client-id-here>",
             "clientSecret": "<paste-client-secret-here>",
             "lockTimeout": 5000,
@@ -141,11 +141,11 @@ If you're using a Raspberry Pi for HomeBridge and have a connected Camera Module
 }
 ```
 
-**authType** (optional): the method of authentication, either "password" or "secret". This is set to "password" for backwards compatibility with previous versions of this plugin, but it is recommended to use the "secret" method to avoid having to keep a username and password in plaintext in the configuration.
+**authType** (optional): the method of authentication, either "password" or "client". This is set to "password" for backwards compatibility with previous versions of this plugin, but it is recommended to use the "client" method to avoid having to keep a username and password in plaintext in the configuration.
 
 **clientId**: Client ID (read "Retrieving a client ID and client secret from Nello")/
 
-**clientSecret** (required for "secret" auth)
+**clientSecret** (required for "client" auth)
 
 **username** (required for "password" auth): the email address of your nello.io account.
 

--- a/functions/signIn.js
+++ b/functions/signIn.js
@@ -1,5 +1,41 @@
 const request = require("request");
 
+function getGrantFormParameters (platform) {
+    if (!platform.config.clientId) {
+        platform.log("No clientId for nello.io provided.");
+        return false;
+    }
+
+    switch (platform.config.authType) {
+        case 'password':
+            if (!platform.config.username || !platform.config.password) {
+                platform.log("No username and/or password for nello.io provided.");
+                return false;
+            }
+            return {
+                grant_type: "password",
+                client_id: platform.config.clientId,
+                username: platform.config.username,
+                password: platform.config.password
+            };
+        
+        case 'client':
+            if (!platform.config.clientSecret) {
+                platform.log("No clientSecret for nello.io provided.");
+                return false;
+            }
+            return {
+                grant_type: "client_credentials",
+                client_id: platform.config.clientId,
+                client_secret: platform.config.clientSecret
+            };
+        
+        default:
+            platform.log("Invalid authType for nello.io provided.");
+            return false;
+    }
+}
+
 module.exports = function (callback) {
     const platform = this;
 
@@ -8,16 +44,10 @@ module.exports = function (callback) {
         platform.log("No Authentication URI for nello.io provided.");
         return callback(false);
     }
-    if (!platform.config.username) {
-        platform.log("No username for nello.io provided. Please make sure to create a dedicated nello.io account for this homebridge plugin.");
-        return callback(false);
-    }
-    if (!platform.config.password) {
-        platform.log("No password for nello.io provided. Please make sure to create a dedicated nello.io account for this homebridge plugin.");
-        return callback(false);
-    }
-    if (!platform.config.clientId) {
-        platform.log("No client ID for nello.io provided. Please make sure that you have requested a client ID from nello.io.");
+    
+    const grantFormParameters = getGrantFormParameters(platform);
+
+    if (!grantFormParameters) {
         return callback(false);
     }
 
@@ -25,16 +55,12 @@ module.exports = function (callback) {
     platform.log("Signing in.");
     platform.token = null;
     platform.locations = [];
+
     request({
         uri: platform.config.authUri + "/oauth/token/",
         method: "POST",
         json: true,
-        form: {
-            "client_id": platform.config.clientId,
-            "username": platform.config.username,
-            "password": platform.config.password,
-            "grant_type": "password"
-        }
+        form: grantFormParameters,
     }, function (error, response, body) {
 
         // Checks if the API returned a positive result

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ function NelloPlatform(log, config, api) {
   // Initializes the configuration
   platform.config.apiUri = "https://public-api.nello.io/v1";
   platform.config.authUri = "https://auth.nello.io";
+  platform.config.authType = platform.config.authType || 'password';
   platform.config.lockTimeout = platform.config.lockTimeout || 5000;
   platform.config.locationUpdateInterval = platform.config.locationUpdateInterval == 0 ? 0 : (platform.config.locationUpdateInterval || 3600000);
   platform.config.exposeReachability = platform.config.exposeReachability;


### PR DESCRIPTION
Nello supports using the client ID & secret to retrieve a token. This PR adds support for using a secret instead of a username and password.