### PR TITLE
Add HMAC handling for socket backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Others
 * The client secret used by this plugin has to be specified in the `config.json` on the PC/Mac/Raspberry running homebridge. Please make sure that nobody can access this device within your local network without permission.
 * In the Apple Home app, a lock can be easily unlocked with a single tap on the icon. Please be careful not to open the door unintentionally.
 * The webhook uses a relay service which is hosted by @AlexanderBabel. You can find the source code of the service here: <https://github.com/AlexanderBabel/nello-backend>. You can override this and configure your own URL if you expose the right ports, look at the docs for more info.
-* Since the Nello webhooks are not signed or authenticated (see [#43](https://github.com/lukasroegner/homebridge-nello/issues/43)), an attacker who discovers your webhook URL will be able to open your door with a simple payload if you enable the "always open switch". This is mitigated by the use of constantly changing unique URLs, but use this feature at your own risk!
 
 ## Development
 

--- a/src/NelloPlatform.ts
+++ b/src/NelloPlatform.ts
@@ -115,12 +115,7 @@ export class NelloPlatform implements DynamicPlatformPlugin {
   }
 
   private async updateLocations(): Promise<void> {
-    try {
-      this.locations = await updateLocations(this);
-    } catch (e) {
-      this.log.warn('Getting locations from nello.io failed', e);
-      throw e;
-    }
+    this.locations = await updateLocations(this);
   }
 
   connectWebhook(): void {
@@ -144,9 +139,8 @@ export class NelloPlatform implements DynamicPlatformPlugin {
     this.log(`Updating webhook for door with ID ${location.location_id} to ${webhookUri}.`);
     try {
       await this.client.updateWebhook(location, webhookUri, hmacKey);
-      this.log(`Updated webhook for door with ID ${location.location_id} to ${webhookUri}.`);
     } catch (e) {
-      this.log('Updating webhook failed.');
+      // already logged by client
     }
   }
 

--- a/src/NelloPlatform.ts
+++ b/src/NelloPlatform.ts
@@ -4,7 +4,7 @@ import type {
 
 import { Config, PLUGIN_NAME, PLATFORM_NAME } from './config';
 import { configureAccessoryServices } from './functions/configureAccessoryServices';
-import { connectWebhook } from './functions/connectWebhook';
+import { connectWebhook, WebhookHandle } from './functions/connectWebhook';
 import { createAccessory } from './functions/createAccessory';
 import { createOrUpdateCamera } from './functions/createOrUpdateCamera';
 import { updateLocations } from './functions/updateLocations';
@@ -81,7 +81,7 @@ export class NelloPlatform implements DynamicPlatformPlugin {
     // Subscribes to the event that is raised when homebrige finished loading cached accessories
     this.api.on('didFinishLaunching', () => {
       this.log('Cached accessories loaded.');
-      void this.startup();
+      void this.setup();
     });
 
     this.api.on('shutdown', () => {
@@ -89,19 +89,28 @@ export class NelloPlatform implements DynamicPlatformPlugin {
     });
   }
 
-  private async startup() {
+  private async setup(nextDelayMinutes = 1) {
     // Initially updates the locations to get the locks
-    await this.updateLocations();
-    await this.connectWebhook();
+    try {
+      await this.updateLocations();
+      this.connectWebhook();
+    } catch (e) {
+      this.log.error(`Setup failed, retrying in ${nextDelayMinutes} minute(s)`);
+      setTimeout(() => {
+        void this.setup(nextDelayMinutes + 1);
+      }, nextDelayMinutes * 60 * 1000);
+      return;
+    }
 
     // Starts the timer for updating locations (i.e. adding and removing locks of the user)
     if (this.config.common.locationUpdateInterval > 0) {
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      setInterval(async () => {
-        await this.updateLocations();
-        // Also generate a new URL periodically
-        await this.connectWebhook();
+      setInterval(() => {
+        void this.updateLocations().catch(() => {});
       }, this.config.common.locationUpdateInterval);
+
+      setInterval(() => {
+        this.connectWebhook();
+      }, this.config.common.webhookUpdateInterval);
     }
   }
 
@@ -110,18 +119,20 @@ export class NelloPlatform implements DynamicPlatformPlugin {
       this.locations = await updateLocations(this);
     } catch (e) {
       this.log.warn('Getting locations from nello.io failed', e);
+      throw e;
     }
   }
 
-  private async connectWebhook() {
+  connectWebhook(): void {
     this.closeWebhook?.();
+    connectWebhook(this);
+  }
 
-    const { url, key, close } = await connectWebhook(this);
-
-    this.closeWebhook = close;
+  async updateWebhooks(handle: WebhookHandle): Promise<void> {
+    this.closeWebhook = handle.close;
 
     await Promise.all(
-      this.getLocations().map((location) => this.updateWebhook(location, url, key)),
+      this.getLocations().map((location) => this.updateWebhook(location, handle.url, handle.key)),
     );
   }
 

--- a/src/functions/connectWebhook.ts
+++ b/src/functions/connectWebhook.ts
@@ -96,7 +96,7 @@ const connectToWebhookRelay = (
   });
 
   socket.on('connect', () => {
-    platform.log('Connected to webhook backend');
+    platform.log('Connected to webhook backend, requesting webhook');
     socket.emit('getWebhook');
   });
 

--- a/src/functions/connectWebhook.ts
+++ b/src/functions/connectWebhook.ts
@@ -9,16 +9,44 @@ import { WebhookData } from '../lib/WebhookData';
 
 import { processWebhookData } from './processWebhookData';
 
-type WebhookHandle = {
+export type WebhookHandle = {
   url: string;
   close: VoidFunction;
   /** Pre-Shared HMAC Key */
   key?: string;
 };
 
+const validateAndProcessWebhook = (opts: {
+  key: string,
+  rawBody: string,
+  hmacDigestFromRequest?: string,
+}, platform: NelloPlatform): void => {
+  const calculatedDigest = crypto
+    .createHmac('sha256', opts.key)
+    .update(opts.rawBody)
+    .digest('hex');
+
+  if (opts.hmacDigestFromRequest !== calculatedDigest) {
+    platform.log.warn('Received webhook with invalid HMAC authentication', opts.rawBody);
+    if (platform.config.common.dryRun) {
+      platform.log.warn('ALLOWING WEBHOOK DATA DUE TO DRY-RUN');
+    } else {
+      platform.log.warn('DISCARDING WEBHOOK DATA');
+      return;
+    }
+  }
+
+  try {
+    void processWebhookData(platform, JSON.parse(opts.rawBody) as WebhookData);
+  } catch (e) {
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    platform.log.warn(`Error processing webhook: ${e}`);
+  }
+};
+
 const registerWebhook = (
   platform: NelloPlatform,
-): Promise<WebhookHandle> => new Promise((resolve) => {
+): void => {
   platform.log('Registering webhook with unique URL and new HMAC key');
 
   const key = crypto.randomBytes(32).toString('hex');
@@ -26,43 +54,14 @@ const registerWebhook = (
 
   const app = express();
 
-  const blockUnauthenticated = (body: string): boolean => {
-    const shouldBlock = !platform.config.common.dryRun;
-
-    const message = shouldBlock ? 'DISCARDING' : 'ALLOWING DUE TO DRY-RUN';
-
-    platform.log.warn(`Received webhook with invalid HMAC authentication, ${message}`, body);
-
-    return shouldBlock;
-  };
-
   app.use(express.text({ type: '*/*' }));
 
   app.put<Record<string, string>, unknown, string, unknown>(`/${uniqueId}`, (req, res) => {
-    const hmacDigestFromRequest = req.header(NELLO_HMAC_HEADER);
-    const jsonString = req.body;
-
-    if (!hmacDigestFromRequest && blockUnauthenticated(jsonString)) {
-      res.status(200).send('OK');
-      return;
-    }
-
-    const calculatedHmacDigest = crypto
-      .createHmac('sha256', key)
-      .update(jsonString)
-      .digest('hex');
-
-    if (hmacDigestFromRequest !== calculatedHmacDigest && blockUnauthenticated(jsonString)) {
-      res.status(200).send('OK');
-      return;
-    }
-
-    try {
-      void processWebhookData(platform, JSON.parse(jsonString));
-    } catch (e) {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      platform.log.warn(`Error processing webhook: ${e}`);
-    }
+    validateAndProcessWebhook({
+      key,
+      hmacDigestFromRequest: req.header(NELLO_HMAC_HEADER),
+      rawBody: req.body,
+    }, platform);
 
     res.status(200).send('OK');
   });
@@ -71,7 +70,7 @@ const registerWebhook = (
 
   const server = app.listen(port, () => {
     platform.log(`Webhook server listening on port ${port}`);
-    resolve({
+    void platform.updateWebhooks({
       url: `${platform.config.common.publicWebhookUrl}${uniqueId}`,
       key,
       close: () => {
@@ -80,26 +79,35 @@ const registerWebhook = (
       },
     });
   });
-});
+};
 
 const connectToWebhookRelay = (
   platform: NelloPlatform,
-): Promise<WebhookHandle> => new Promise((resolve) => {
+): void => {
+  platform.log('Connecting to webhook relay service');
+
   const socket = io(SOCKET_BACKEND, { transports: ['websocket'] });
+
+  const key = crypto.randomBytes(32).toString('hex');
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   socket.on('error', (err: any) => {
-    platform.log(err);
+    platform.log.error(err);
   });
 
   socket.on('connect', () => {
-    platform.log('Connected to webhook backend.');
+    platform.log('Connected to webhook backend');
     socket.emit('getWebhook');
   });
 
+  socket.on('reconnecting', (attempt: number) => {
+    platform.log.warn(`Reconnecting to webhook backend, attempt ${attempt}...`);
+  });
+
   socket.on('webhook', (data: { url: string }) => {
-    resolve({
+    void platform.updateWebhooks({
       url: data.url,
+      key,
       close: () => {
         platform.log('Disconnecting from webhook backend');
         socket.close();
@@ -107,21 +115,23 @@ const connectToWebhookRelay = (
     });
   });
 
-  socket.on('call', (data: WebhookData) => {
-    if (data && data.action) {
-      void processWebhookData(platform, data);
-    }
+  // https://github.com/AlexanderBabel/nello-backend/blob/master/index.js
+  socket.on('call', (data: { rawBody: string, hmacSignature?: string }) => {
+    validateAndProcessWebhook({
+      key,
+      hmacDigestFromRequest: data.hmacSignature,
+      rawBody: data.rawBody,
+    }, platform);
   });
-});
+};
 
 /**
  * Opens connection to the webhook backend.
  */
-export const connectWebhook = (platform: NelloPlatform): Promise<WebhookHandle> => {
+export const connectWebhook = (platform: NelloPlatform): void => {
   if (platform.config.common.publicWebhookUrl) {
-    return registerWebhook(platform);
+    registerWebhook(platform);
+  } else {
+    connectToWebhookRelay(platform);
   }
-
-  platform.log('Connecting to webhook relay service');
-  return connectToWebhookRelay(platform);
 };

--- a/src/functions/processWebhookData.ts
+++ b/src/functions/processWebhookData.ts
@@ -13,10 +13,10 @@ export const processWebhookData = async (
       platform.log(`${data.data.name} opened the door with ID ${data.data.location_id}`);
       break;
     case WebhookAction.TimeWindow:
-      platform.log(`The door with ID ${data.data.location_id} has been opened in the time window ${data.data.name}.`);
+      platform.log(`The door with ID ${data.data.location_id} was opened in the time window ${data.data.name}.`);
       break;
     case WebhookAction.HomeZoneUnlock:
-      platform.log(`${data.data.name} opened the door with ID ${data.data.location_id} via geofence.`);
+      platform.log(`${data.data.name} opened the door with ID ${data.data.location_id} via Homezone Unlock.`);
       break;
     case WebhookAction.DidNotOpen:
       platform.log(`Someone rang the bell of the door with ID ${data.data.location_id}.`);

--- a/src/lib/resolveConfig.ts
+++ b/src/lib/resolveConfig.ts
@@ -39,6 +39,7 @@ export const resolveConfig = (
       locationUpdateInterval: common.locationUpdateInterval === 0
         ? 0
         : (common.locationUpdateInterval ?? defaultCommon.locationUpdateInterval),
+      webhookUpdateInterval: common.webhookUpdateInterval ?? defaultCommon.webhookUpdateInterval,
 
       exposeReachability: common.exposeReachability ?? defaultCommon.exposeReachability,
 


### PR DESCRIPTION
~Waiting on https://github.com/AlexanderBabel/nello-backend/pull/6~

- Add HMAC handling for socket backend
- Add shorter webhookUpdateInterval
- Fix not handling socket webhook reconnects (the URL was not updated)
- Improve setup error handling

Resolves #43